### PR TITLE
Changes to interop with IAM

### DIFF
--- a/src/oidcc.erl
+++ b/src/oidcc.erl
@@ -137,8 +137,14 @@ retrieve_token(AuthCode, OpenIdProviderId) ->
               <<"&redirect_uri=">>/binary, LeEncoded/binary >>,
     Header0 = [ {<<"content-type">>, <<"application/x-www-form-urlencoded">>}],
 
-    {Body, Header} = add_authentication(Body0, Header0, AuthMethods, ClientId,
-                                        Secret),
+    NewAuthMethods=case lists:member(<<"client_secret_basic">>, AuthMethods) of
+                       true ->
+                           [<<"client_secret_basic">>];
+                       false ->
+                           AuthMethods
+                   end,
+    {Body, Header} = add_authentication(Body0, Header0, NewAuthMethods,
+                                        ClientId, Secret),
     return_token(oidcc_http_util:sync_http(post, Endpoint, Header, Body)).
 
 %% @doc

--- a/src/oidcc_openid_provider.erl
+++ b/src/oidcc_openid_provider.erl
@@ -242,6 +242,15 @@ extract_supported_keys([#{ kty := <<"RSA">>,
     E = binary:decode_unsigned(base64url:decode(E0)),
     Key = #{kty => rsa, alg => rs256, use => sign, key => [E, N], kid => Kid },
     extract_supported_keys(T, [Key | List]);
+extract_supported_keys([#{ kty := <<"RSA">>,
+                           n := N0,
+                           e := E0
+                         } = Map|T], List) ->
+    Kid = maps:get(kid, Map, undefined),
+    N = binary:decode_unsigned(base64url:decode(N0)),
+    E = binary:decode_unsigned(base64url:decode(E0)),
+    Key = #{kty => rsa, key => [E, N], kid => Kid },
+    extract_supported_keys(T, [Key | List]);
 extract_supported_keys([_H|T], List) ->
     extract_supported_keys(T, List).
 


### PR DESCRIPTION
dont enforce optionial information for keys 
use client_secret_basic supported allowed