### PR TITLE
Fix authmethods and Issuer verification

### DIFF
--- a/src/oidcc.erl
+++ b/src/oidcc.erl
@@ -308,9 +308,10 @@ retrieve_a_token(QsBodyIn, OpenIdProviderInfo) ->
 retrieve_a_token(QsBodyIn, Pkce, OpenIdProviderInfo) ->
     #{ client_id := ClientId,
        client_secret := Secret,
-       token_endpoint := Endpoint,
-       token_endpoint_auth_methods_supported := AuthMethods
+       token_endpoint := Endpoint
      } = OpenIdProviderInfo,
+    AuthMethods = maps:get(token_endpoint_auth_methods_supported,
+                           OpenIdProviderInfo, [<<"client_secret_basic">>]),
     AuthMethod = select_preferred_auth(AuthMethods),
     Header0 = [ {<<"content-type">>, <<"application/x-www-form-urlencoded">>}],
     {QsBody, Header} = add_authentication_code_verifier(QsBodyIn, Header0,

--- a/test/oidcc_openid_provider_test.erl
+++ b/test/oidcc_openid_provider_test.erl
@@ -49,7 +49,7 @@ set_test() ->
 fetch_config_test() ->
     Id = <<"some id">>,
 
-    ConfigEndpoint = <<"https://my.provider/info">>,
+    ConfigEndpoint = <<"https://my.provider/.well-known/openid-configuration">>,
     KeyEndpoint = <<"https://my.provider/keys">>,
     ConfigBody1 = <<"{\"issuer\":\"https://my.provider\",">>,
     ConfigBody2 = <<" \"jwks_uri\": \"https://my.provider/keys\" }">>,
@@ -167,5 +167,3 @@ wait_till_ready(Pid) ->
             timer:sleep(100),
             wait_till_ready(Pid)
     end.
-
-


### PR DESCRIPTION
some provider do not publish the supported authmetods, in this case 'basic auth' is according to the specs the fallback. Implemented in first commit.

According to the specs the Issuer can be derived from the configuration endpoint, implemented in the 
second commit; fix #64 
Needed to adjust test accordingly