### PR TITLE
implement basic sync http caching, fix #142

### DIFF
--- a/src/oidcc_http_cache.erl
+++ b/src/oidcc_http_cache.erl
@@ -1,0 +1,146 @@
+-module(oidcc_http_cache).
+-behaviour(gen_server).
+
+%% API.
+-export([start_link/0]).
+-export([stop/0]).
+-export([cache_http_result/3]).
+-export([lookup_http_call/2]).
+-export([trigger_cleaning/0]).
+
+
+%% gen_server.
+-export([init/1]).
+-export([handle_call/3]).
+-export([handle_cast/2]).
+-export([handle_info/2]).
+-export([terminate/2]).
+-export([code_change/3]).
+
+-record(state, {
+          ets_cache = undefined,
+          ets_time = undefined,
+          cache_duration = undefined,
+          clean_timeout = undefined,
+          last_clean = undefined
+         }).
+
+%% API.
+
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec stop() -> ok.
+stop() ->
+    gen_server:cast(?MODULE, stop).
+
+cache_http_result(Method, Request, Result) ->
+    Key = {Method, Request},
+    gen_server:call(?MODULE, {cache_http, Key, Result}).
+
+lookup_http_call(Method, Request) ->
+    Key = {Method, Request},
+    read_cache(Key).
+
+trigger_cleaning() ->
+    gen_server:cast(?MODULE, clean_cache).
+
+%% gen_server.
+init(_) ->
+    EtsCache = ets:new(oidcc_ets_http_cache, [set, protected, named_table]),
+    EtsTime = ets:new(oidcc_ets_http_cache_time, [ordered_set, private]),
+    CacheDuration = application:get_env(oidcc, http_cache_duration, none),
+    CleanTimeout = application:get_env(oidcc, http_cache_clean, 60),
+    Now = erlang:system_time(seconds),
+    {ok, #state{ets_cache=EtsCache,
+                ets_time = EtsTime,
+                cache_duration = CacheDuration,
+                clean_timeout = CleanTimeout,
+                last_clean = Now
+               }}.
+
+handle_call({cache_http, Key, Result}, _From,
+            #state{ets_cache = EtsCache, ets_time = EtsTime,
+                   cache_duration=CacheDuration} = State) ->
+    ok = trigger_cleaning_if_needed(State),
+    ok = insert_into_cache(Key, Result, EtsCache, EtsTime, CacheDuration),
+    {reply, ok, State};
+handle_call(_Request, _From, State) ->
+    {reply, ignored, State}.
+
+
+insert_into_cache(Key, Result, EtsCache, EtsTime, Duration)
+  when is_integer(Duration), Duration > 0 ->
+    Now = erlang:system_time(seconds),
+    Timeout = Now + Duration,
+    true = ets:insert(EtsCache, {Key, Timeout, Result}),
+    true = ets:insert(EtsTime, {Timeout, Key}),
+    ok;
+insert_into_cache(_Key, _Result, _EtsCache, _EtsTime, _Duration)  ->
+    ok.
+
+
+handle_cast(clean_cache, #state{ets_cache=EtsCache,
+                                ets_time=EtsTime
+                               } = State) ->
+    Now = erlang:system_time(seconds),
+    case ets:first(EtsTime) of
+        '$end_of_table' ->
+            ok;
+        Timeout ->
+            delete_entry_if_outdated(Timeout, EtsCache, EtsTime, Now >= Timeout)
+    end,
+    {noreply, State#state{last_clean=Now}};
+handle_cast(stop, State) ->
+    {stop, normal, State};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+read_cache(Key) ->
+    Now = erlang:system_time(seconds),
+    case ets:lookup(oidcc_ets_http_cache, Key) of
+        [{Key, Timeout, Result}] ->
+            return_if_not_outdated(Result, Timeout > Now);
+        [] ->
+            {error, not_found}
+    end.
+
+trigger_cleaning_if_needed(#state{last_clean=LastClean,
+                                  clean_timeout=CleanTimeout}) ->
+    Now = erlang:system_time(seconds),
+    case (Now - LastClean) >= CleanTimeout of
+        true ->
+            trigger_cleaning(),
+            ok;
+        _ ->
+            ok
+    end.
+
+
+return_if_not_outdated(Result, true) ->
+    {ok, Result};
+return_if_not_outdated(_, _) ->
+    trigger_cleaning(),
+    {error, outdated}.
+
+delete_entry_if_outdated(Timeout, EtsCache, EtsTime, true) ->
+    [{Timeout, Key}] = ets:lookup(EtsTime, Timeout),
+    true = ets:delete(EtsTime, Timeout),
+    true = ets:delete(EtsCache, Key),
+    trigger_cleaning(),
+    ok;
+delete_entry_if_outdated(_Timeout, _EtsCache, _EtsTime, _) ->
+    ok.

--- a/src/oidcc_sup.erl
+++ b/src/oidcc_sup.erl
@@ -13,7 +13,8 @@ init([]) ->
              openid_session_manager(),
              openid_client(),
              openid_provider_supervisor(),
-             session_supervisor()
+             session_supervisor(),
+             http_cache()
             ],
     {ok, {{one_for_one, 1, 5}, Procs}}.
 
@@ -45,5 +46,11 @@ openid_session_manager() ->
 openid_client() ->
     #{ id => client,
        start => {oidcc_client, start_link, []},
+       type => worker
+     }.
+
+http_cache() ->
+    #{ id => cache,
+       start => {oidcc_http_cache, start_link, []},
        type => worker
      }.

--- a/test/oidcc_http_cache_test.erl
+++ b/test/oidcc_http_cache_test.erl
@@ -1,0 +1,92 @@
+-module(oidcc_http_cache_test).
+-include_lib("eunit/include/eunit.hrl").
+
+
+start_stop_test() ->
+    {ok, Pid} = oidcc_http_cache:start_link(),
+    ok = oidcc_http_cache:stop(),
+    test_util:wait_for_process_to_die(Pid, 100),
+    ok.
+
+insert_lookup_unconf_test() ->
+    {ok, Pid} = oidcc_http_cache:start_link(),
+
+    %% default behaviour of unconfigured
+    ?assertEqual({error, not_found}, oidcc_http_cache:lookup_http_call(a, b)),
+    ?assertEqual(ok, oidcc_http_cache:cache_http_result(a, b, c)),
+    ?assertEqual({error, not_found}, oidcc_http_cache:lookup_http_call(a, b)),
+
+    ok = oidcc_http_cache:stop(),
+    test_util:wait_for_process_to_die(Pid, 100),
+    ok.
+
+insert_lookup_conf_test() ->
+    application:set_env(oidcc, http_cache_duration, 30),
+    {ok, Pid} = oidcc_http_cache:start_link(),
+    application:unset_env(oidcc, http_cache_duration),
+
+    ?assertEqual({error, not_found}, oidcc_http_cache:lookup_http_call(a, b)),
+    ?assertEqual(ok, oidcc_http_cache:cache_http_result(a, b, c)),
+    ?assertEqual({ok, c}, oidcc_http_cache:lookup_http_call(a, b)),
+
+    ok = oidcc_http_cache:stop(),
+    test_util:wait_for_process_to_die(Pid, 100),
+    ok.
+
+clean_test() ->
+    application:set_env(oidcc, http_cache_duration, 1),
+    {ok, Pid} = oidcc_http_cache:start_link(),
+    application:unset_env(oidcc, http_cache_duration),
+
+    ?assertEqual(ok, oidcc_http_cache:cache_http_result(a, b, c)),
+    ?assertEqual({ok, c}, oidcc_http_cache:lookup_http_call(a, b)),
+    oidcc_http_cache:trigger_cleaning(),
+    ?assertEqual({ok, c}, oidcc_http_cache:lookup_http_call(a, b)),
+
+    timer:sleep(1000),
+    ?assertEqual({error, outdated}, oidcc_http_cache:lookup_http_call(a, b)),
+    oidcc_http_cache:trigger_cleaning(),
+    wait_for_cache(),
+    ?assertEqual({error, not_found}, oidcc_http_cache:lookup_http_call(a, b)),
+
+    ok = oidcc_http_cache:stop(),
+    test_util:wait_for_process_to_die(Pid, 100),
+    ok.
+
+auto_clean_test() ->
+    application:set_env(oidcc, http_cache_duration, 1),
+    application:set_env(oidcc, http_cache_clean, 1),
+    {ok, Pid} = oidcc_http_cache:start_link(),
+    application:unset_env(oidcc, http_cache_duration),
+    application:unset_env(oidcc, http_cache_clean),
+
+
+    ?assertEqual(ok, oidcc_http_cache:cache_http_result(a, b, c)),
+    ?assertEqual({ok, c}, oidcc_http_cache:lookup_http_call(a, b)),
+    timer:sleep(1000),
+    ?assertEqual(ok, oidcc_http_cache:cache_http_result(b, c, d)),
+    ?assertEqual({ok, d}, oidcc_http_cache:lookup_http_call(b, c)),
+
+    ?assertEqual({error, not_found}, oidcc_http_cache:lookup_http_call(a, b)),
+
+    ok = oidcc_http_cache:stop(),
+    test_util:wait_for_process_to_die(Pid, 100),
+    ok.
+
+garbage_test() ->
+    {ok, Pid} = oidcc_http_cache:start_link(),
+    ignored = gen_server:call(Pid,unsupported_glibberish),
+    ok = gen_server:cast(Pid,unsupported_glibberish),
+    Pid ! some_unsupported_message,
+    ok = oidcc_http_cache:stop(),
+    ok = test_util:wait_for_process_to_die(Pid, 100),
+    ok.
+
+wait_for_cache() ->
+    case ets:info(oidcc_ets_http_cache, size) of
+        0 ->
+            ok;
+        _ ->
+            timer:sleep(10),
+            wait_for_cache()
+    end.

--- a/test/oidcc_http_util_test.erl
+++ b/test/oidcc_http_util_test.erl
@@ -35,3 +35,20 @@ http_async_get_test() ->
         {http, {Id, _Result}} ->
             ok
     end.
+
+
+http_cache_test() ->
+    application:set_env(oidcc, http_cache_duration, 1),
+    {ok, Pid} = oidcc_http_cache:start_link(),
+    application:unset_env(oidcc, http_cache_duration),
+
+    Url1 = <<"http://google.de">>,
+    {ok, #{status := 200}} = oidcc_http_util:sync_http(get, Url1, [], true),
+    {ok, #{status := 200}} = oidcc_http_util:sync_http(get, Url1, [], true),
+    timer:sleep(1),
+    {ok, #{status := 200}} = oidcc_http_util:sync_http(get, Url1, [], true),
+
+
+    ok = oidcc_http_cache:stop(),
+    test_util:wait_for_process_to_die(Pid, 50),
+    ok.


### PR DESCRIPTION
introducing two new settings:
- http_cache_duration: how long (in seconds) to keep the data cached, default none (not active)
- http_cache_clean: number of seconds after which a cache clean is triggered, it is only checke on storing data in cache, not reading, default 60