### PR TITLE
Add support for dynamic removal of openid providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _build/
 doc/
 .erlang.mk/
 .tts.plt
+.rebar3/
 elvis
 xrefr
 cover/

--- a/src/oidcc.erl
+++ b/src/oidcc.erl
@@ -1,5 +1,6 @@
 -module(oidcc).
 
+-export([remove_openid_provider/1]).
 -export([add_openid_provider/2]).
 -export([add_openid_provider/3]).
 -export([find_openid_provider/1]).
@@ -17,6 +18,15 @@
 -export([retrieve_fresh_token/3]).
 -export([introspect_token/2]).
 -export([register_module/1]).
+
+
+%% @doc
+%% remove an OpenID Connect Provider from the list of possible Providers
+%% @end
+-spec remove_openid_provider(binary()) -> ok | {error, Reason::any()}.
+remove_openid_provider(IssuerOrConfigEP) ->
+  oidcc_openid_provider_mgr:remove_openid_provider(IssuerOrConfigEP).
+
 
 
 

--- a/src/oidcc_openid_provider_sup.erl
+++ b/src/oidcc_openid_provider_sup.erl
@@ -1,10 +1,15 @@
 -module(oidcc_openid_provider_sup).
 -behaviour(supervisor).
 
+-export([remove_openid_provider/1]).
 -export([add_openid_provider/2]).
 
 -export([start_link/0]).
 -export([init/1]).
+
+remove_openid_provider(Id) ->
+    ok = supervisor:terminate_child(?MODULE, Id),
+    supervisor:delete_child(?MODULE, Id).
 
 add_openid_provider(Id, Config) ->
     supervisor:start_child(?MODULE, openid_provider_spec(Id, Config)).
@@ -20,4 +25,3 @@ openid_provider_spec(Id, Config) ->
     #{ id => Id,
        start => {oidcc_openid_provider, start_link, [Id, Config]}
      }.
-

--- a/test/oidcc_openid_provider_mgr_test.erl
+++ b/test/oidcc_openid_provider_mgr_test.erl
@@ -26,6 +26,35 @@ simple_add_test() ->
     ok = stop_meck(ProvPid),
     ok.
 
+remove_test() ->
+    Config = #{name => <<"some name">>,
+               description => <<"some description">>,
+               client_id => <<"123">>,
+               client_secret => <<"dont tell">>,
+               issuer_or_endpoint => <<"well.known">>,
+               local_endpoint => <<"/here">>
+              },
+    {ok, ProvPid} = meck(),
+    ok = meck:expect(oidcc_openid_provider_sup, remove_openid_provider, fun(_) -> ok end),
+
+    {ok, Pid} = oidcc_openid_provider_mgr:start_link(),
+    {ok, Id, ProvPid} = oidcc_openid_provider_mgr:add_openid_provider(Config),
+    ok = oidcc_openid_provider_mgr:remove_openid_provider(Id),
+    ok = oidcc_openid_provider_mgr:stop(),
+    ok = test_util:wait_for_process_to_die(Pid, 100),
+
+    true = meck:validate(oidcc_openid_provider_sup),
+    ok = stop_meck(ProvPid),
+    ok.
+
+unknown_remove_test() ->
+  {ok, ProvPid} = meck(),
+  {ok, Pid} = oidcc_openid_provider_mgr:start_link(),
+  {error, not_found} = oidcc_openid_provider_mgr:remove_openid_provider("unknown"),
+  ok = oidcc_openid_provider_mgr:stop(),
+  ok = test_util:wait_for_process_to_die(Pid, 100),
+  ok = stop_meck(ProvPid),
+  ok.
 
 id_add_test() ->
     Id = <<"123">>,

--- a/test/oidcc_test.erl
+++ b/test/oidcc_test.erl
@@ -1,6 +1,16 @@
 -module(oidcc_test).
 -include_lib("eunit/include/eunit.hrl").
 
+remove_openid_provider_test() ->
+  ok = meck:expect(oidcc_openid_provider_mgr, remove_openid_provider, fun(_) -> ok end),
+
+  Id = <<"123345456">>,
+  ok = oidcc:remove_openid_provider(Id),
+
+  true = meck:validate(oidcc_openid_provider_mgr),
+  meck:unload(oidcc_openid_provider_mgr),
+  ok.
+
 add_openid_provider_test() ->
     MyPid = self(),
     RandomId = <<"6">>,


### PR DESCRIPTION
We are using `oidcc` in a more dynamic nature, where customers are able to add/remove providers at will and we have to sync the list with our database. In order to do this we required a `delete_openid_provider` method.

I did my best to fit the code style previously in use, but my Erlang knowledge is limited. Please let me know if there is anything you would like me to change.

I added several tests, but I noticed there is not a real integration test. The actual removal of the provider is left to the existing code that deals with `DOWN` messages for the provider. To remove the provider, I simply shoot down the process.