### PR TITLE
Fixed encoding of CodeVerifier

### DIFF
--- a/src/oidcc_session.erl
+++ b/src/oidcc_session.erl
@@ -176,4 +176,4 @@ apply_s256(_, CodeVerifier) ->
      }.
 
 gen_code_verifier() ->
-    base64:encode(crypto:strong_rand_bytes(64)).
+    base64url:encode(crypto:strong_rand_bytes(64)).


### PR DESCRIPTION
We had several cases with using an Okta OpenID Connect link that the PKCE verification failed. It seemed to be the case when the base64 encoding needed the `=` character to pad the string the PKCE verification would fail. Looking at the spec, this is indeed a non-allowed character:

> code_verifier = high-entropy cryptographic random STRING using the unreserved characters [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~" from Section 2.3 of [RFC3986], with a minimum length of 43 characters and a maximum length of 128 characters.

(Source: https://tools.ietf.org/html/rfc7636)

For some generated verifiers the PKCE verification would succeed, for other it would fail. By using the more strict `base64url` method, we solve the issue.